### PR TITLE
Version 0.3.3 - Remove port argument

### DIFF
--- a/libaskocli/__init__.py
+++ b/libaskocli/__init__.py
@@ -28,7 +28,6 @@ def askomics_url(parser):
     """
 
     parser.add_argument('-a', '--askomics', help='AskOmics URL', required=True)
-    parser.add_argument('-p', '--port', help='AskOmics port')
 
 
 class RequestApi(object):

--- a/libaskocli/actions/integrate.py
+++ b/libaskocli/actions/integrate.py
@@ -33,10 +33,7 @@ class Integrate(object):
 
         args = parser.parse_args(args)
 
-        if args.port:
-            url = args.askomics + ':' + args.port
-        else:
-            url = args.askomics
+        url = args.askomics
 
         api = RequestApi(url, args.apikey, args.file_type)
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='askocli',
-    version='0.3.2',
+    version='0.3.3',
     description='Command line interface for a distant AskOmics',
     author='Xavier Garnier',
     author_email='xavier.garnier@irisa.fr',
     url='https://github.com/xgaia/asko-cli',
-    download_url='https://github.com/askomics/asko-cli/archive/0.3.2.git tar.gz',
+    download_url='https://github.com/askomics/asko-cli/archive/0.3.3.git tar.gz',
     install_requires=['requests>=2.4.3'],
     packages=find_packages(),
     license='AGPL',


### PR DESCRIPTION
remove the `-p, --port` argument because it's problematic when askomics run at `localhost:6543/askomics` for exemple.